### PR TITLE
Remove note about building msgpack-c with GCC that I forgot earlier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,6 @@ make install
 
 > On FreeBSD, you need to `pkg install autotools` and invoke `gmake` instead of `make`.
 
-To build with GCC instead of clang:
-
-```console
-./configure --prefix=$HOME/msgpack_gcc
-```
-
 ### **Autobahn**|Cpp
 
 To get **Autobahn**|Cpp library and examples, clone the repo


### PR DESCRIPTION
I overlooked this snippet in my last pull request.

msgpack-c in its current (1.0 and later) incarnation is a
header-only library, so we're not concerned about anything that
their build produces. We just want the installed header files,
which are of course the same for clang and GCC.
