### PR TITLE
Implement a custom (non-msgpack) API for accessing [kw_]arguments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ web/reports*
 build
 doc/_upload*
 doc/_doxygen*
+
+# Qt Creator
+CMakeLists.txt.user

--- a/README.md
+++ b/README.md
@@ -30,24 +30,20 @@ Here is how programming with C++ and **Autobahn**|Cpp looks like.
 
 ```c++
 auto c1 = session.call("com.mathservice.add2", std::make_tuple(23, 777))
-    .then([&](future<wamp_call_result> result) {
-        std::tuple<uint64_t> args;
-        result.get().arguments().convert(args);
-        std::cout << "Got call result " << std::get<0>(args) << std::endl;
+    .then([&](boost::future<wamp_call_result> result) {
+        std::cout << "Got call result " << result.get().argument<uint64_t>(0) << std::endl;
     });
 ```
 
 **Registering a remoted Procedure**
 ```c++
 auto r1 = session.provide("com.myapp.cpp.square",
-    [](wamp_invocation invocation) {
+    [](autobahn::wamp_invocation invocation) {
         std::cout << "Procedure is invoked .." << endl;
-        std::tuple<uint64_t> args;
-        invocation->arguments().convert(args);
-        uint64_t x = std::get<0>(args);
+        uint64_t x = invocation->argument<uint64_t>(0);
         return x * x;
     })
-    .then([](future<wamp_registration> reg) {
+    .then([](boost::future<autobahn::wamp_registration> reg) {
         std::cout << "Registered with ID " << reg.get().id() << std::endl;
     });
 ```
@@ -65,7 +61,7 @@ auto opts = PublishOptions();
 opts.acknowledge = True;
 
 session.publish("com.myapp.topic2", std::make_tuple(23, true, std::string("hello")), opts)
-    .then([](future<wamp_publication> pub) {
+    .then([](boost::future<autobahn::wamp_publication> pub) {
         std::cout << "Published with ID " << pub.get().id() << std::endl;
     });
 ```
@@ -74,12 +70,10 @@ session.publish("com.myapp.topic2", std::make_tuple(23, true, std::string("hello
 
 ```c++
 auto s1 = session.subscribe("com.myapp.topic1",
-    [](const wamp_event& event) {
-        std::tuple<uint64_t> args;
-        event.arguments().convert(args);
-        std::cout << "Got event: " << std::get<0>(args) << std::endl;
+    [](const autobahn::wamp_event& event) {
+        std::cout << "Got event: " << event.argument<uint64_t>(0) << std::endl;
     })
-    .then([](future<wamp_subscription> sub) {
+    .then([](boost::future<autobahn::wamp_subscription> sub) {
         std::cout << "Subscribed with ID " << sub.get().id() << std::endl;
     });
 ```

--- a/autobahn/wamp_call_result.hpp
+++ b/autobahn/wamp_call_result.hpp
@@ -20,6 +20,7 @@
 #define AUTOBAHN_WAMP_CALL_RESULT_HPP
 
 #include <msgpack.hpp>
+#include <string>
 
 namespace autobahn {
 
@@ -34,8 +35,145 @@ public:
     wamp_call_result& operator=(const wamp_call_result& other);
     wamp_call_result& operator=(wamp_call_result&& other);
 
-    const msgpack::object& arguments() const;
-    const msgpack::object& kw_arguments() const;
+    /*!
+     * The number of positional arguments returned from the call.
+     */
+    std::size_t number_of_arguments() const;
+
+    /*!
+     * The number of keyword arguments returned from the call.
+     */
+    std::size_t number_of_kw_arguments() const;
+
+    /*!
+     * The positional argument returned from the call with the given @p index, converted to type T.
+     *
+     * Example:
+     * `std::string id = result.argument<std::string>(0); // first positional argument`
+     *
+     * @throw std::out_of_range
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T argument(std::size_t index) const;
+
+    /*!
+     * The positional arguments returned from the call, converted to a list type.
+     *
+     * Example:
+     * `auto args = result.arguments<std::tuple<std::string>>();`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename List>
+    List arguments() const;
+
+    /*!
+     * Convert and assign the positional arguments returned from the call to the given @p args list.
+     *
+     * Example:
+     * ```
+     * std::tuple<std::string> args;
+     * result.get_arguments(args);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename List>
+    void get_arguments(List& args) const;
+
+    /*!
+     * Convert and assign the positional arguments to a given list of individual parameters.
+     *
+     * Enables a syntax that lets you declare variables individually, but list them in a
+     * single space to empathize parameter order. This will also throw if the number of
+     * arguments to the invocation doesn't match the number of given parameters.
+     *
+     * Example:
+     * ```
+     * uint64_t id;
+     * std::string name;
+     * invocation->get_each_argument(id, name);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename... T>
+    inline void get_each_argument(T&... args) const;
+
+    /*!
+     * The keyword argument returned from the call with the given @p key, converted to type T.
+     *
+     * Overloads are provided for `std::string` and `char*` as @p key type.
+     *
+     * This function uses key string comparisons to find the matching value, O(n) with n being
+     * the number of map elements. Memory allocation for keys is avoided though. For larger maps,
+     * you might want to prioritize look-up performance by using `std::map`, `std::unordered_map`
+     * or custom types with custom deserialization. To do this, use kw_arguments<Map>() or
+     * get_kw_arguments<Map>(map), then access the items from there.
+     *
+     * Example:
+     * `std::string id = result.kw_argument<std::string>("id");`
+     *
+     * @throw std::out_of_range
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T kw_argument(const std::string& key) const;
+
+    template <typename T>
+    T kw_argument(const char* key) const;
+
+    /*!
+     * The keyword argument returned from the call with the given @p key, converted to type T,
+     * or the given @p fallback if no such key was passed.
+     *
+     * Overloads are provided for `std::string` and `char*` as @p key type.
+     *
+     * This function uses key string comparisons to find the matching value, O(n) with n being
+     * the number of map elements. Memory allocation for keys is avoided though. For larger maps,
+     * you might want to prioritize look-up performance by using `std::map`, `std::unordered_map`
+     * or custom types with custom deserialization. To do this, use kw_arguments<Map>() or
+     * get_kw_arguments<Map>(map), then access the items from there.
+     *
+     * Example:
+     * `std::string id = result.kw_argument_or("id", std::string());`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T kw_argument_or(const std::string& key, const T& fallback) const;
+
+    template <typename T>
+    T kw_argument_or(const char* key, const T& fallback) const;
+
+    /*!
+     * The keyword arguments returned from the call, converted to a map type.
+     *
+     * Example:
+     * `auto kw_args = result.kw_arguments<std::unordered_map<std::string, msgpack::object>>();`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename Map>
+    Map kw_arguments() const;
+
+    /*!
+     * Convert and assign the keyword arguments returned from the call to the given @p kw_args map.
+     *
+     * Example:
+     * ```
+     * std::unordered_map<std::string, msgpack::object> kw_args;
+     * result.get_kw_arguments(kw_args);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename Map>
+    void get_kw_arguments(Map& kw_args) const;
+
+    //
+    // functions only called internally by wamp_session
 
     void set_arguments(const msgpack::object& arguments);
     void set_kw_arguments(const msgpack::object& kw_arguments);

--- a/autobahn/wamp_call_result.ipp
+++ b/autobahn/wamp_call_result.ipp
@@ -80,14 +80,124 @@ inline wamp_call_result& wamp_call_result::operator=(wamp_call_result&& other)
     return *this;
 }
 
-inline const msgpack::object& wamp_call_result::arguments() const
+inline std::size_t wamp_call_result::number_of_arguments() const
 {
-    return m_arguments;
+    return m_arguments.type == msgpack::type::ARRAY ? m_arguments.via.array.size : 0;
 }
 
-inline const msgpack::object& wamp_call_result::kw_arguments() const
+inline std::size_t wamp_call_result::number_of_kw_arguments() const
 {
-    return m_kw_arguments;
+    return m_kw_arguments.type == msgpack::type::MAP ? m_kw_arguments.via.map.size : 0;
+}
+
+template <typename T>
+inline T wamp_call_result::argument(std::size_t index) const
+{
+    if (m_arguments.type != msgpack::type::ARRAY || m_arguments.via.array.size <= index) {
+        throw std::out_of_range("no argument at index " + std::to_string(index));
+    }
+    return m_arguments.via.array.ptr[index].as<T>();
+}
+
+template <typename List>
+inline List wamp_call_result::arguments() const
+{
+    return m_arguments.as<List>();
+}
+
+template <typename List>
+inline void wamp_call_result::get_arguments(List& args) const
+{
+    m_arguments.convert(args);
+}
+
+template <typename... T>
+inline void wamp_call_result::get_each_argument(T&... args) const
+{
+    auto args_tuple = std::make_tuple(std::ref(args)...);
+    m_arguments.convert(args_tuple);
+}
+
+template <typename T>
+inline T wamp_call_result::kw_argument(const std::string& key) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key.size() == kv.key.via.str.size
+                && key.compare(0, key.size(), kv.key.via.str.ptr, kv.key.via.str.size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    throw std::out_of_range(key + " keyword argument doesn't exist");
+}
+
+template <typename T>
+inline T wamp_call_result::kw_argument(const char* key) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    std::size_t key_size = strlen(key);
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key_size == kv.key.via.str.size
+                && memcmp(key, kv.key.via.str.ptr, key_size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    throw std::out_of_range(std::string(key) + " keyword argument doesn't exist");
+}
+
+template <typename T>
+inline T wamp_call_result::kw_argument_or(const std::string& key, const T& fallback) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key.size() == kv.key.via.str.size
+                && key.compare(0, key.size(), kv.key.via.str.ptr, kv.key.via.str.size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    return fallback;
+}
+
+template <typename T>
+inline T wamp_call_result::kw_argument_or(const char* key, const T& fallback) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    std::size_t key_size = strlen(key);
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key_size == kv.key.via.str.size
+                && memcmp(key, kv.key.via.str.ptr, key_size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    throw fallback;
+}
+
+template <typename Map>
+inline Map wamp_call_result::kw_arguments() const
+{
+    return m_kw_arguments.as<Map>();
+}
+
+template <typename Map>
+inline void wamp_call_result::get_kw_arguments(Map& kw_args) const
+{
+    m_kw_arguments.convert(kw_args);
 }
 
 inline void wamp_call_result::set_arguments(const msgpack::object& arguments)

--- a/autobahn/wamp_event.hpp
+++ b/autobahn/wamp_event.hpp
@@ -22,6 +22,7 @@
 #include "wamp_arguments.hpp"
 
 #include <msgpack.hpp>
+#include <string>
 
 namespace autobahn {
 
@@ -30,8 +31,145 @@ class wamp_event
 public:
     wamp_event();
 
-    const msgpack::object& arguments() const;
-    const msgpack::object& kw_arguments() const;
+    /*!
+     * The number of positional arguments published by the event.
+     */
+    std::size_t number_of_arguments() const;
+
+    /*!
+     * The number of keyword arguments published by the event.
+     */
+    std::size_t number_of_kw_arguments() const;
+
+    /*!
+     * The positional argument published by the event with the given @p index, converted to type T.
+     *
+     * Example:
+     * `std::string id = event.argument<std::string>(0); // first positional argument`
+     *
+     * @throw std::out_of_range
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T argument(std::size_t index) const;
+
+    /*!
+     * The positional arguments published by the event, converted to a list type.
+     *
+     * Example:
+     * `auto args = event.arguments<std::tuple<std::string>>();`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename List>
+    List arguments() const;
+
+    /*!
+     * Convert and assign the positional arguments published by the event to the given @p args list.
+     *
+     * Example:
+     * ```
+     * std::tuple<std::string> args;
+     * event.get_arguments(args);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename List>
+    void get_arguments(List& args) const;
+
+    /*!
+     * Convert and assign the positional arguments to a given list of individual parameters.
+     *
+     * Enables a syntax that lets you declare variables individually, but list them in a
+     * single space to empathize parameter order. This will also throw if the number of
+     * arguments to the invocation doesn't match the number of given parameters.
+     *
+     * Example:
+     * ```
+     * uint64_t id;
+     * std::string name;
+     * invocation->get_each_argument(id, name);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename... T>
+    inline void get_each_argument(T&... args) const;
+
+    /*!
+     * The keyword argument published by the event with the given @p key, converted to type T.
+     *
+     * Overloads are provided for `std::string` and `char*` as @p key type.
+     *
+     * This function uses key string comparisons to find the matching value, O(n) with n being
+     * the number of map elements. Memory allocation for keys is avoided though. For larger maps,
+     * you might want to prioritize look-up performance by using `std::map`, `std::unordered_map`
+     * or custom types with custom deserialization. To do this, use kw_arguments<Map>() or
+     * get_kw_arguments<Map>(map), then access the items from there.
+     *
+     * Example:
+     * `std::string id = event.kw_argument<std::string>("id");`
+     *
+     * @throw std::out_of_range
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T kw_argument(const std::string& key) const;
+
+    template <typename T>
+    T kw_argument(const char* key) const;
+
+    /*!
+     * The keyword argument published by the event with the given @p key, converted to type T,
+     * or the given @p fallback if no such key was passed.
+     *
+     * Overloads are provided for `std::string` and `char*` as @p key type.
+     *
+     * This function uses key string comparisons to find the matching value, O(n) with n being
+     * the number of map elements. Memory allocation for keys is avoided though. For larger maps,
+     * you might want to prioritize look-up performance by using `std::map`, `std::unordered_map`
+     * or custom types with custom deserialization. To do this, use kw_arguments<Map>() or
+     * get_kw_arguments<Map>(map), then access the items from there.
+     *
+     * Example:
+     * `std::string id = event.kw_argument_or("id", std::string());`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T kw_argument_or(const std::string& key, const T& fallback) const;
+
+    template <typename T>
+    T kw_argument_or(const char* key, const T& fallback) const;
+
+    /*!
+     * The keyword arguments published by the event, converted to a map type.
+     *
+     * Example:
+     * `auto kw_args = event.kw_arguments<std::unordered_map<std::string, msgpack::object>>();`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename Map>
+    Map kw_arguments() const;
+
+    /*!
+     * Convert and assign the keyword arguments published by the event to the given @p kw_args map.
+     *
+     * Example:
+     * ```
+     * std::unordered_map<std::string, msgpack::object> kw_args;
+     * event.get_kw_arguments(kw_args);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename Map>
+    void get_kw_arguments(Map& kw_args) const;
+
+    //
+    // functions only called internally by wamp_session
 
     void set_arguments(const msgpack::object& arguments);
     void set_kw_arguments(const msgpack::object& kw_arguments);

--- a/autobahn/wamp_event.ipp
+++ b/autobahn/wamp_event.ipp
@@ -16,6 +16,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <stdexcept>
+
 namespace autobahn {
 
 inline wamp_event::wamp_event()
@@ -24,14 +26,124 @@ inline wamp_event::wamp_event()
 {
 }
 
-inline const msgpack::object& wamp_event::arguments() const
+inline std::size_t wamp_event::number_of_arguments() const
 {
-    return m_arguments;
+    return m_arguments.type == msgpack::type::ARRAY ? m_arguments.via.array.size : 0;
 }
 
-inline const msgpack::object& wamp_event::kw_arguments() const
+inline std::size_t wamp_event::number_of_kw_arguments() const
 {
-    return m_kw_arguments;
+    return m_kw_arguments.type == msgpack::type::MAP ? m_kw_arguments.via.map.size : 0;
+}
+
+template <typename T>
+inline T wamp_event::argument(std::size_t index) const
+{
+    if (m_arguments.type != msgpack::type::ARRAY || m_arguments.via.array.size <= index) {
+        throw std::out_of_range("no argument at index " + std::to_string(index));
+    }
+    return m_arguments.via.array.ptr[index].as<T>();
+}
+
+template <typename List>
+inline List wamp_event::arguments() const
+{
+    return m_arguments.as<List>();
+}
+
+template <typename List>
+inline void wamp_event::get_arguments(List& args) const
+{
+    m_arguments.convert(args);
+}
+
+template <typename... T>
+inline void wamp_event::get_each_argument(T&... args) const
+{
+    auto args_tuple = std::make_tuple(std::ref(args)...);
+    m_arguments.convert(args_tuple);
+}
+
+template <typename T>
+inline T wamp_event::kw_argument(const std::string& key) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key.size() == kv.key.via.str.size
+                && key.compare(0, key.size(), kv.key.via.str.ptr, kv.key.via.str.size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    throw std::out_of_range(key + " keyword argument doesn't exist");
+}
+
+template <typename T>
+inline T wamp_event::kw_argument(const char* key) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    std::size_t key_size = strlen(key);
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key_size == kv.key.via.str.size
+                && memcmp(key, kv.key.via.str.ptr, key_size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    throw std::out_of_range(std::string(key) + " keyword argument doesn't exist");
+}
+
+template <typename T>
+inline T wamp_event::kw_argument_or(const std::string& key, const T& fallback) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key.size() == kv.key.via.str.size
+                && key.compare(0, key.size(), kv.key.via.str.ptr, kv.key.via.str.size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    return fallback;
+}
+
+template <typename T>
+inline T wamp_event::kw_argument_or(const char* key, const T& fallback) const
+{
+    if (m_kw_arguments.type != msgpack::type::MAP) {
+        throw msgpack::type_error();
+    }
+    std::size_t key_size = strlen(key);
+    for (std::size_t i = 0; i < m_kw_arguments.via.map.size; ++i) {
+        const msgpack::object_kv& kv = m_kw_arguments.via.map.ptr[i];
+        if (kv.key.type == msgpack::type::STR && key_size == kv.key.via.str.size
+                && memcmp(key, kv.key.via.str.ptr, key_size) == 0)
+        {
+            return kv.val.as<T>();
+        }
+    }
+    throw fallback;
+}
+
+template <typename Map>
+inline Map wamp_event::kw_arguments() const
+{
+    return m_kw_arguments.as<Map>();
+}
+
+template <typename Map>
+inline void wamp_event::get_kw_arguments(Map& kw_args) const
+{
+    m_kw_arguments.convert(kw_args);
 }
 
 inline void wamp_event::set_arguments(const msgpack::object& arguments)

--- a/autobahn/wamp_invocation.hpp
+++ b/autobahn/wamp_invocation.hpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <memory>
 #include <msgpack.hpp>
+#include <string>
 
 namespace autobahn {
 
@@ -35,14 +36,141 @@ public:
     wamp_invocation_impl(wamp_invocation_impl&&) = delete; // copy wamp_invocation instead
 
     /*!
-     * The positional arguments passed to the invocation.
+     * The number of positional arguments passed to the invocation.
      */
-    const msgpack::object& arguments() const;
+    std::size_t number_of_arguments() const;
 
     /*!
-     * The keyword arguments passed to the invocation.
+     * The number of keyword arguments passed to the invocation.
      */
-    const msgpack::object& kw_arguments() const;
+    std::size_t number_of_kw_arguments() const;
+
+    /*!
+     * The positional argument passed to the invocation with the given @p index, converted to type T.
+     *
+     * Example:
+     * `std::string id = invocation->argument<std::string>(0); // first positional argument`
+     *
+     * @throw std::out_of_range
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T argument(std::size_t index) const;
+
+    /*!
+     * The positional arguments passed to the invocation, converted to a list type.
+     *
+     * Example:
+     * `auto args = invocation->arguments<std::tuple<std::string>>();`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename List>
+    List arguments() const;
+
+    /*!
+     * Convert and assign the positional arguments to the given @p args list.
+     *
+     * Example:
+     * ```
+     * std::tuple<std::string> args;
+     * invocation->get_arguments(args);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename List>
+    void get_arguments(List& args) const;
+
+    /*!
+     * Convert and assign the positional arguments to a given list of individual parameters.
+     *
+     * Enables a syntax that lets you declare variables individually, but list them in a
+     * single space to empathize parameter order. This will also throw if the number of
+     * arguments to the invocation doesn't match the number of given parameters.
+     *
+     * Example:
+     * ```
+     * uint64_t id;
+     * std::string name;
+     * invocation->get_each_argument(id, name);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename... T>
+    inline void get_each_argument(T&... args) const;
+
+    /*!
+     * The keyword argument passed to the invocation with the given @p key, converted to type T.
+     *
+     * Overloads are provided for `std::string` and `char*` as @p key type.
+     *
+     * This function uses key string comparisons to find the matching value, O(n) with n being
+     * the number of map elements. Memory allocation for keys is avoided though. For larger maps,
+     * you might want to prioritize look-up performance by using `std::map`, `std::unordered_map`
+     * or custom types with custom deserialization. To do this, use kw_arguments<Map>() or
+     * get_kw_arguments<Map>(map), then access the items from there.
+     *
+     * Example:
+     * `std::string id = invocation->kw_argument<std::string>("id");`
+     *
+     * @throw std::out_of_range
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T kw_argument(const std::string& key) const;
+
+    template <typename T>
+    T kw_argument(const char* key) const;
+
+    /*!
+     * The keyword argument passed to the invocation with the given @p key, converted to type T,
+     * or the given @p fallback if no such key was passed.
+     *
+     * Overloads are provided for `std::string` and `char*` as @p key type.
+     *
+     * This function uses key string comparisons to find the matching value, O(n) with n being
+     * the number of map elements. Memory allocation for keys is avoided though. For larger maps,
+     * you might want to prioritize look-up performance by using `std::map`, `std::unordered_map`
+     * or custom types with custom deserialization. To do this, use kw_arguments<Map>() or
+     * get_kw_arguments<Map>(map), then access the items from there.
+     *
+     * Example:
+     * `std::string id = invocation->kw_argument_or("id", std::string());`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename T>
+    T kw_argument_or(const std::string& key, const T& fallback) const;
+
+    template <typename T>
+    T kw_argument_or(const char* key, const T& fallback) const;
+
+    /*!
+     * The keyword arguments passed to the invocation, converted to a map type.
+     *
+     * Example:
+     * `auto kw_args = invocation->kw_arguments<std::unordered_map<std::string, msgpack::object>>();`
+     *
+     * @throw std::bad_cast
+     */
+    template <typename Map>
+    Map kw_arguments() const;
+
+    /*!
+     * Convert and assign the keyword arguments to the given @p kw_args map.
+     *
+     * Example:
+     * ```
+     * std::unordered_map<std::string, msgpack::object> kw_args;
+     * invocation->get_kw_arguments(kw_args);
+     * ```
+     *
+     * @throw std::bad_cast
+     */
+    template <typename Map>
+    void get_kw_arguments(Map& kw_args) const;
 
     /*!
      * Reply to the invocation with an empty result.

--- a/examples/callee.cpp
+++ b/examples/callee.cpp
@@ -27,15 +27,13 @@
 
 void add(autobahn::wamp_invocation invocation)
 {
-    std::tuple<uint64_t, uint64_t> arguments;
-    invocation->arguments().convert(arguments);
+    auto a = invocation->argument<uint64_t>(0);
+    auto b = invocation->argument<uint64_t>(1);
 
-    std::tuple<uint16_t> result(
-                std::get<0>(arguments) + std::get<1>(arguments));
-    invocation->result(result);
+    invocation->result(std::make_tuple(a + b));
 }
 
-int main (int argc, char** argv)
+int main(int argc, char** argv)
 {
     std::cerr << "Boost: " << BOOST_VERSION << std::endl;
 

--- a/examples/caller.cpp
+++ b/examples/caller.cpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <tuple>
 
-int main (int argc, char** argv)
+int main(int argc, char** argv)
 {
     std::cerr << "Boost: " << BOOST_VERSION << std::endl;
 
@@ -64,9 +64,8 @@ int main (int argc, char** argv)
                             std::tuple<uint64_t, uint64_t> arguments(23, 777);
                             call_future = session->call("com.examples.calculator.add", arguments).then(
                             [&](boost::future<autobahn::wamp_call_result> result) {
-                                std::tuple<uint64_t> result_arguments;
-                                result.get().arguments().convert(result_arguments);
-                                std::cerr << "call result: " << std::get<0>(result_arguments) << std::endl;
+                                uint64_t sum = result.get().argument<uint64_t>(0);
+                                std::cerr << "call result: " << sum << std::endl;
                                 leave_future = session->leave().then([&](boost::future<std::string> reason) {
                                     std::cerr << "left session (" << reason.get() << ")" << std::endl;
                                     stop_future = session->stop().then([&](boost::future<void> stopped) {

--- a/examples/publisher.cpp
+++ b/examples/publisher.cpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <tuple>
 
-int main (int argc, char** argv)
+int main(int argc, char** argv)
 {
     try {
         auto parameters = get_parameters(argc, argv);

--- a/examples/subscriber.cpp
+++ b/examples/subscriber.cpp
@@ -25,12 +25,10 @@
 
 void topic1(const autobahn::wamp_event& event)
 {
-    std::tuple<std::string> event_arguments;
-    event.arguments().convert(event_arguments);
-    std::cerr << "received event: " << std::get<0>(event_arguments) << std::endl;
+    std::cerr << "received event: " << event.argument<uint64_t>(0) << std::endl;
 }
 
-int main (int argc, char** argv)
+int main(int argc, char** argv)
 {
     try {
         auto parameters = get_parameters(argc, argv);


### PR DESCRIPTION
This applies to wamp_call_result, wamp_event and wamp_invocation,
all of which expose [kw_]arguments through the same API.

The old API returned a msgpack::object from both arguments() and
kw_arguments(), leaving conversion of arguments to the user:

```
std::tuple<uint64_t, uint64_t> args;
event.arguments().convert(args);
uint64_t x = std::get<0>(args);
uint64_t y = std::get<1>(args);

std::map<std::string, msgpack::object> kw_args;
event.kw_arguments().convert(kw_args);
uint64_t id = kw_args["id"].as<uint64_t>();
std::string name = kw_args["name"].as<std::string>();
```

The new API hides the msgpack::object and provides more concise
replacements for converting the entire list or map. Furthermore,
accessors for single elements are provided. See below for an
example featuring all new different access method variants:

```
// In simple cases, this is now one line instead of three.
uint64_t x = event.argument<uint64_t>(0);

// Extract a list and check argument count without a tuple.
uint64_t y;
event.get_each_argument(x, y);

// Putting everything into a complete list can still be useful.
auto args = event.arguments<std::tuple<uint64_t, uint64_t>>();
x = std::get<0>(args);

// Or using the previous style, in case the line gets too long.
std::tuple<uint64_t, uint64_t> event_args;
event.get_arguments(event_args);
x = std::get<0>(event_args);

// Keyword arguments can skip the intermediate map for ease of use.
// Gets us poorer lookup behaviour, but no unnecessary allocations.
uint64_t id = event.kw_argument<uint64_t>("id");
std::string name = event.kw_argument<std::string>("name");

// Extra convenience for keys that might be missing from the map.
id = event.kw_argument_or<uint64_t>("id", 0); // make sure the right type is passed
name = event.kw_argument_or("name", std::string()); // no template argument necessary

// And again, conversion to a full map similar to arguments.
auto kw_args = event.kw_arguments<std::map<std::string, msgpack::object>>();
id = kw_args["id"].as<uint64_t>();
name = kw_args["name"].as<std::string>();

// Using the previous style, splitting declaration and conversion.
std::map<std::string, msgpack::object> event_kw_args;
event.get_kw_arguments(event_kw_args);
id = kw_args["id"].as<uint64_t>();
name = kw_args["name"].as<std::string>();
```
