### PR TITLE
Disable unused-local-typedef errors to allow building with newest Clang/Xcode7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 2.8)
 
 project(autobahn-cpp)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror ${CMAKE_CXX_FLAGS}")
+if(NOT MSVC)
+    set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -Wno-unused-local-typedef ${CMAKE_CXX_FLAGS}")
+endif()
+
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
     if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")


### PR DESCRIPTION
Also make msvc build work as well.
