### PR TITLE
add ifndef for boost futures to get rid of warnings on windows

### DIFF
--- a/autobahn/wamp_call.hpp
+++ b/autobahn/wamp_call.hpp
@@ -34,9 +34,11 @@
 #include "wamp_call_result.hpp"
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 #include <boost/thread/future.hpp>
 
 #include <msgpack.hpp>

--- a/autobahn/wamp_rawsocket_transport.hpp
+++ b/autobahn/wamp_rawsocket_transport.hpp
@@ -32,9 +32,11 @@
 #define AUTOBAHN_WAMP_NETWORK_TRANSPORT_HPP
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 
 #include "wamp_transport.hpp"
 

--- a/autobahn/wamp_register_request.hpp
+++ b/autobahn/wamp_register_request.hpp
@@ -35,9 +35,11 @@
 #include "wamp_registration.hpp"
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 #include <boost/thread/future.hpp>
 
 namespace autobahn {

--- a/autobahn/wamp_session.hpp
+++ b/autobahn/wamp_session.hpp
@@ -40,9 +40,11 @@
 #include "wamp_transport_handler.hpp"
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 #include <boost/asio.hpp>
 #include <boost/thread/future.hpp>
 #include <cstdint>

--- a/autobahn/wamp_subscribe_request.hpp
+++ b/autobahn/wamp_subscribe_request.hpp
@@ -35,9 +35,11 @@
 #include "wamp_subscription.hpp"
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 #include <boost/thread/future.hpp>
 
 namespace autobahn {

--- a/autobahn/wamp_tcp_transport.hpp
+++ b/autobahn/wamp_tcp_transport.hpp
@@ -32,9 +32,11 @@
 #define AUTOBAHN_WAMP_TCP_TRANSPORT_HPP
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 
 #include "wamp_rawsocket_transport.hpp"
 

--- a/autobahn/wamp_transport.hpp
+++ b/autobahn/wamp_transport.hpp
@@ -32,9 +32,11 @@
 #define AUTOBAHN_WAMP_TRANSPORT_HPP
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 
 #include <boost/thread/future.hpp>
 #include <memory>

--- a/autobahn/wamp_transport_handler.hpp
+++ b/autobahn/wamp_transport_handler.hpp
@@ -32,9 +32,11 @@
 #define AUTOBAHN_WAMP_TRANSPORT_HANDLER_HPP
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 
 #include "wamp_message.hpp"
 

--- a/autobahn/wamp_unsubscribe_request.hpp
+++ b/autobahn/wamp_unsubscribe_request.hpp
@@ -32,9 +32,11 @@
 #define AUTOBAHN_WAMP_UNSUBSCRIBE_REQUEST_HPP
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 #include <boost/thread/future.hpp>
 
 namespace autobahn {

--- a/autobahn/wamp_websocket_transport.hpp
+++ b/autobahn/wamp_websocket_transport.hpp
@@ -32,9 +32,11 @@
 #define AUTOBAHN_WEBSOCKET_TRANSPORT_HPP
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 
 #include "wamp_transport.hpp"
 

--- a/autobahn/wamp_websocketpp_websocket_transport.hpp
+++ b/autobahn/wamp_websocketpp_websocket_transport.hpp
@@ -32,9 +32,11 @@
 #define AUTOBAHN_WEBSOCKETPP_WEBSOCKET_TRANSPORT_HPP
 
 // http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 #define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
 
 #ifdef _WIN32
 #pragma warning(disable:4996) //Windows XP cancel async IO always fails with operation_not_supported


### PR DESCRIPTION
This eliminates warnings on windows when the macro is already defined.
